### PR TITLE
Remove styling conflicts with Recent Jobs widget

### DIFF
--- a/includes/class-template.php
+++ b/includes/class-template.php
@@ -104,22 +104,18 @@ class Astoundify_Job_Manager_Regions_Template extends Astoundify_Job_Manager_Reg
 	 * @since 1.0.0
 	 */
 	public function the_job_location( $job_location, $post ) {
-		if ( is_singular( 'job_listing' ) ) {
-			return get_the_term_list( $post->ID, 'job_listing_region', '', ', ', '' );
-		} else {
-			$terms = wp_get_object_terms( $post->ID, 'job_listing_region', array( 'orderby' => 'term_order', 'order' => 'desc') );
+		$terms = wp_get_object_terms( $post->ID, 'job_listing_region', array( 'orderby' => 'term_order', 'order' => 'desc') );
 
-			if ( empty( $terms ) ) {
-				return;
-			}
-
-			$names = array();
-
-			foreach ( $terms as $term ) {
-				$names[] = $term->name;
-			}
-
-			return implode( ', ', $names );
+		if ( empty( $terms ) ) {
+			return;
 		}
+
+		$names = array();
+
+		foreach ( $terms as $term ) {
+			$names[] = $term->name;
+		}
+
+		return implode( ', ', $names );
 	}
 }


### PR DESCRIPTION
The use of [get_the_term_list](https://codex.wordpress.org/Function_Reference/get_the_term_list) caused styling errors in the Recent Jobs widget by adding <a> tags around each list item.  This removes that issue, but does not account for any specific reasons why the original code may be needed for the single pages.  I'm assuming that may only matter for listings with multiple locations, but in my testing, this new code worked fine on my single job listings.