### PR TITLE
Use $.isFunction to check for Chosen and Select2

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -34,11 +34,11 @@
 		},
 
 		addSubmission: function() {
-			if ( typeof chosen === "function" ) {
+			if ( $.isFunction($.fn.chosen) ) {
 				$( '#job_region, #resume_region' ).chosen( {
 					search_contains: true,
 				} );
-			} else {
+			} else if( $.isFunction($.fn.select2) ) {
 				$( '#job_region, #resume_region' ).select2( this.select2_args );
 			}
 		},

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -68,7 +68,7 @@
 						search_contains: true
 				};
 
-				if ( typeof chosen === "function" ) {
+				if ( $.isFunction($.fn.chosen) ) {
 					if ( ! wrapper ) {
 						$regions.chosen( args );
 					} else {


### PR DESCRIPTION
Use `$.isFunction` instead of `typeof` to check for Chosen ... also check for select2 before calling fixes #70

Should make sure that chosen and select2 exists before trying to init, allowing fallback to standard select without js error on page